### PR TITLE
Updated feature set of bma456w in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ The BMA456 is an ultra-small, triaxial, low-g acceleration sensor with digital i
 - Step detector
 - Step counter
 - Step activity
-- Tap
-	- Single tap
-	- Double tap
+- Wrist wear wakeup
 
 ### BMA456H
 


### PR DESCRIPTION
The feature set of the bma456w API is outdated.
The current firmware version does not include support for tap detection. More advanced wrist wear wakeup is implemented instead. The README was updated to reflect this change.

Additionally, the application note for wearables feature set should be updated to reflect the changes of the last commit.
The application note still lists tap detection features, the current bma456w firmware does not support this.